### PR TITLE
fix(tokenize): assistant's content starts with '\n' leads to a wierd bug

### DIFF
--- a/hakkero/__init__.py
+++ b/hakkero/__init__.py
@@ -2,4 +2,4 @@
 # -*- coding: utf-8 -*-
 #
 
-__version__ = "1.2.17"
+__version__ = "1.2.18"

--- a/hakkero/__init__.py
+++ b/hakkero/__init__.py
@@ -2,4 +2,4 @@
 # -*- coding: utf-8 -*-
 #
 
-__version__ = "1.2.16"
+__version__ = "1.2.17"

--- a/hakkero/dataset/segment_dataset.py
+++ b/hakkero/dataset/segment_dataset.py
@@ -84,7 +84,7 @@ class SegmentDataset(torch.utils.data.IterableDataset):
                 sample["data"], self.tokenizer, processor=self.processor, path=self.path, **self.kwargs
             )
         except TokenizationError as e:
-            logger.warning(f"[{self.path}:{sample['info'][1]}]: {e}\n{sample['data']}")
+            logger.warning(f"[rank={self.rank}, world_size={self.world_size}][{self.path}:{sample['info'][1]}]: {e} => {sample['uid']}\n{sample['data']}")
             return [dict(used=[sample["info"]])]
 
         try:
@@ -100,7 +100,7 @@ class SegmentDataset(torch.utils.data.IterableDataset):
                     data, self.max_length, sample["info"], self.random
                 )
         except SegmentationError as e:
-            logger.warning(f"[{self.path}:{sample['info'][1]}]: {e} => {sample['uid']}")
+            logger.warning(f"[rank={self.rank}, world_size={self.world_size}][{self.path}:{sample['info'][1]}]: {e} => {sample['uid']}")
             return [dict(used=[sample["info"]])]
 
         for s in segments:

--- a/hakkero/dataset/strategy/check.py
+++ b/hakkero/dataset/strategy/check.py
@@ -54,9 +54,29 @@ def check_preference(data):
         return False, f"messages should be {FMT_PREFERENCES}, but got {data}"
 
     if not isinstance(data["chosen"], str) or not isinstance(data["rejected"], str):
-        return False, "chosen or rejected should be string"
+        return False, f"chosen or rejected should be string, but got {data}"
 
-    return check_message(data["context"])
+    # check context
+    context = data["context"]
+    if len(context) == 0:
+        return False, f"context should not be empty, but got {data}"
+
+    if not isinstance(context, list) or not all(isinstance(d, dict) for d in context):
+        return False, f"context should be {FMT_MESSAGES}, but got {data}"
+
+    if context[0]["role"] not in ("system", "user"):
+        return False, f"context[0]['role'] should be 'system' or 'user', but got {context[0]['role']}"
+
+    if context[-1]["role"] != "user":
+        return False, f"context[-1]['role'] should be 'user', but got {context[-1]['role']}"
+
+    if context[0]["role"] == "system" and (len(context[1:]) + 1) % 2 != 0:
+        return False, f"context should be in pairs between user and assistant, but got {data}"
+
+    if any([len(d["content"]) == 0 for d in context]):
+        return False, f"message in context should not be empty, but some of them are empty. see {data}"
+
+    return True, ""
 
 
 check_func = {


### PR DESCRIPTION

Here is a token `\n\n` in Qwen2.5 tokenizer vocab.

![image](https://github.com/user-attachments/assets/3f4264d3-87dd-4dac-b37b-fa1ca926112c)
